### PR TITLE
Windows compatibility

### DIFF
--- a/ippserver/__main__.py
+++ b/ippserver/__main__.py
@@ -22,7 +22,10 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description='An IPP server')
     parser.add_argument('-v', '--verbose', action='count', help='Add debugging')
     parser.add_argument('-H', '--host', type=str, default='localhost', metavar='HOST', help='Address to listen on')
+    parser.add_argument('-f', '--hostname', type=str, default='localhost', metavar='HOSTNAME', help='Hostname that will be included in printer\'s URI')
     parser.add_argument('-p', '--port', type=int, required=True, metavar='PORT', help='Port to listen on')
+    parser.add_argument('-u', '--uuid', type=str, default='884d7c0a-f449-45a7-8bbe-095e2943d313', metavar='UUID', help='Printer UUID')
+    parser.add_argument('-n', '--name', type=str, default='Virtual Printer', metavar='NAME', help='Printer name')
 
     parser_action = parser.add_subparsers(help='Actions', dest='action')
 
@@ -57,28 +60,44 @@ def behaviour_from_parsed_args(args):
     if args.action == 'save':
         return behaviour.SaveFilePrinter(
             directory=args.directory,
-            filename_ext='pdf' if args.pdf else 'ps')
+            filename_ext='pdf' if args.pdf else 'ps',
+            server_addr=(args.hostname, args.port),
+            printer_name=args.name,
+            printer_uuid=args.uuid)
     if args.action == 'run':
         return behaviour.RunCommandPrinter(
             command=args.command,
             use_env=args.env,
-            filename_ext='pdf' if args.pdf else 'ps')
+            filename_ext='pdf' if args.pdf else 'ps',
+            server_addr=(args.hostname, args.port),
+            printer_name=args.name,
+            printer_uuid=args.uuid)
     if args.action == 'saveandrun':
         return behaviour.SaveAndRunPrinter(
             command=args.command,
             use_env=args.env,
             directory=args.directory,
-            filename_ext='pdf' if args.pdf else 'ps')
+            filename_ext='pdf' if args.pdf else 'ps',
+            server_addr=(args.hostname, args.port),
+            printer_name=args.name,
+            printer_uuid=args.uuid)
     if args.action == 'pc2paper':
         pc2paper_config = Pc2Paper.from_config_file(args.config)
         return behaviour.PostageServicePrinter(
             service_api=pc2paper_config,
-            filename_ext='pdf' if args.pdf else 'ps')
+            filename_ext='pdf' if args.pdf else 'ps',
+            server_addr=(args.hostname, args.port),
+            printer_name=args.name,
+            printer_uuid=args.uuid)
     if args.action == 'load':
         module, name = args.path[0].rsplit(".", 1)
         return getattr(importlib.import_module(module), name)(*args.command)
     if args.action == 'reject':
-        return behaviour.RejectAllPrinter()
+        return behaviour.RejectAllPrinter(
+            server_addr=(args.hostname, args.port),
+            printer_name=args.name,
+            printer_uuid=args.uuid)
+
     raise RuntimeError(args)
 
 

--- a/ippserver/data/404.txt
+++ b/ippserver/data/404.txt
@@ -1,1 +1,0 @@
-Page does not exist

--- a/ippserver/data/error.txt
+++ b/ippserver/data/error.txt
@@ -1,1 +1,0 @@
-There was an error.

--- a/ippserver/data/homepage.txt
+++ b/ippserver/data/homepage.txt
@@ -1,1 +1,0 @@
-This is h2g2bob's ipp-server.py

--- a/ippserver/ppd.py
+++ b/ippserver/ppd.py
@@ -61,7 +61,7 @@ class BasicPdfPPD(BasicPostscriptPPD):
     model = 'ipp-server-pdf'
 
     def text(self):
-        return super(BasicPdfPPD, self).text() + b'''
+        return super().text() + b'''
 *% The printer can only handle PDF files, so get CUPS to send that
 *% https://en.wikipedia.org/wiki/CUPS#Filter_system
 *% https://www.cups.org/doc/spec-ppd.html

--- a/ippserver/server.py
+++ b/ippserver/server.py
@@ -19,10 +19,6 @@ import os.path
 from . import request
 
 
-def local_file_location(filename):
-    return os.path.join(os.path.dirname(__file__), 'data', filename)
-
-
 def _get_next_chunk(rfile):
     while True:
         chunk_size_s = rfile.readline()
@@ -108,8 +104,7 @@ class IPPRequestHandler(BaseHTTPRequestHandler):
             self.send_headers(
                 status=200, content_type='text/plain'
             )
-            with open(local_file_location('homepage.txt'), 'rb') as wwwfile:
-                self.wfile.write(wwwfile.read())
+            self.wfile.write(b'IPP server is running ...')
         elif self.path.endswith('.ppd'):
             self.send_headers(
                 status=200, content_type='text/plain'
@@ -119,8 +114,7 @@ class IPPRequestHandler(BaseHTTPRequestHandler):
             self.send_headers(
                 status=404, content_type='text/plain'
             )
-            with open(local_file_location('404.txt'), 'rb') as wwwfile:
-                self.wfile.write(wwwfile.read())
+            self.wfile.write(b'404 Not Found')
 
     def handle_expect_100(self):
         """ Disable """

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,6 @@ setup(
       url='http://github.com/h2g2bob/ipp-server',
       packages=find_packages(exclude=["tests"]),
       test_suite="tests.test_request",
-      package_data={
-        'ippserver': ['data/*'],
-      },
       classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
       license="BSD2",
       description='An IPP server which acts like a printer',
       long_description='A module which implements enough of IPP to fool CUPS into thinking it is a real printer.',
-      version='0.2',
+      version='0.3',
       url='http://github.com/h2g2bob/ipp-server',
       packages=find_packages(exclude=["tests"]),
       test_suite="tests.test_request",


### PR DESCRIPTION
Changes to be able to add this virtual printer on Windows machine:

- added ```media-supported```, ```media-default``` attributes set to ISO A4
- added ```printer-uuid``` attribute, it should be constant as it identifies the specific printer
- ```printer-uri``` should now return the correct hostname & port (it was hardcoded before), the suffix is ```/ipp/print```
- ```printer-name``` can now be parametrised, this name is visible in Windows when you add the printer
- replaced www pages content with inline values instead of storing them in separate files

Tested on Windows 10 & Windows Server 2022