### PR TITLE
Determine file extension based on job file content

### DIFF
--- a/ippserver/__main__.py
+++ b/ippserver/__main__.py
@@ -14,7 +14,7 @@ __package__ = "ippserver"
 from . import behaviour
 from .pc2paper import Pc2Paper
 from .server import run_server, IPPServer, IPPRequestHandler
-
+from .ppd import BasicPostscriptPPD, BasicPdfPPD
 
 def parse_args(args=None):
     pdf_help = 'Request that CUPs sends the document as a PDF file, instead of a PS file. CUPs detects this setting when ADDING a printer: you may need to re-add the printer on a different port'
@@ -60,7 +60,7 @@ def behaviour_from_parsed_args(args):
     if args.action == 'save':
         return behaviour.SaveFilePrinter(
             directory=args.directory,
-            filename_ext='pdf' if args.pdf else 'ps',
+            ppd=BasicPdfPPD() if args.pdf else BasicPostscriptPPD(),
             server_addr=(args.hostname, args.port),
             printer_name=args.name,
             printer_uuid=args.uuid)
@@ -68,7 +68,7 @@ def behaviour_from_parsed_args(args):
         return behaviour.RunCommandPrinter(
             command=args.command,
             use_env=args.env,
-            filename_ext='pdf' if args.pdf else 'ps',
+            ppd=BasicPdfPPD() if args.pdf else BasicPostscriptPPD(),
             server_addr=(args.hostname, args.port),
             printer_name=args.name,
             printer_uuid=args.uuid)
@@ -77,7 +77,7 @@ def behaviour_from_parsed_args(args):
             command=args.command,
             use_env=args.env,
             directory=args.directory,
-            filename_ext='pdf' if args.pdf else 'ps',
+            ppd=BasicPdfPPD() if args.pdf else BasicPostscriptPPD(),
             server_addr=(args.hostname, args.port),
             printer_name=args.name,
             printer_uuid=args.uuid)
@@ -85,7 +85,7 @@ def behaviour_from_parsed_args(args):
         pc2paper_config = Pc2Paper.from_config_file(args.config)
         return behaviour.PostageServicePrinter(
             service_api=pc2paper_config,
-            filename_ext='pdf' if args.pdf else 'ps',
+            ppd=BasicPdfPPD() if args.pdf else BasicPostscriptPPD(),
             server_addr=(args.hostname, args.port),
             printer_name=args.name,
             printer_uuid=args.uuid)

--- a/ippserver/server.py
+++ b/ippserver/server.py
@@ -127,12 +127,12 @@ class IPPRequestHandler(BaseHTTPRequestHandler):
             self.send_headers(
                 status=100, content_type='application/ipp'
             )
-            postscript_file = self.rfile
+            data_file = self.rfile
         else:
-            postscript_file = None
+            data_file = None
 
         ipp_response = self.server.behaviour.handle_ipp(
-            self.ipp_request, postscript_file
+            self.ipp_request, data_file
         ).to_string()
         self.send_headers(
             status=200, content_type='application/ipp',


### PR DESCRIPTION
The type of file that is sent to the printer depends on how the printer is configured on the client side (```-m``` parameter in ```lpadmin``` command for Linux/Mac).